### PR TITLE
Set docker version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           path: /mdsw
 
       - setup_remote_docker:
-          docker_layer_caching: true
+          version: 19.03.13
 
       - run:
           name: Get info


### PR DESCRIPTION
This explicitly sets the Docker version. If we don't set the version,
CircleCI defaults to using 17.03.0 which is a version that CircleCI is
deprecating.

This also removes layer caching. I don't think we really want that; I
think we want to build fresh containers and pick up recent versions of
system libraries and build tools.