### PR TITLE
Fix link making so it doesn't balk the second time

### DIFF
--- a/bin/build_breakpad.sh
+++ b/bin/build_breakpad.sh
@@ -37,7 +37,9 @@ PATH=$(pwd)/depot_tools:$PATH
 
 # depot_tools only works if Python 2 is "python", but the python2 package
 # in buster installs it as /usr/bin/python2, so we link it.
-ln -s /usr/bin/python2 /usr/bin/python
+if [ ! -h /usr/bin/python ]; then
+    ln -s /usr/bin/python2 /usr/bin/python
+fi
 
 # Checkout and build Breakpad
 echo "PREFIX: ${PREFIX:=$(pwd)/build/breakpad}"


### PR DESCRIPTION
If you run `build_breakpad.sh` multiple times, building the link would balk because it was already there. This changes that to check first.