### PR TITLE
Add stricter error options in bash scripts

### DIFF
--- a/bin/build_breakpad.sh
+++ b/bin/build_breakpad.sh
@@ -10,8 +10,7 @@
 # run for local builds if necessary without assuming the Taskcluster
 # environment.
 
-# Failures in this script should cause the build to fail
-set -v -e -x
+set -euxo pipefail
 
 # Build the revision used in the snapshot unless otherwise specified.
 # Update this if you update the snapshot!
@@ -81,11 +80,10 @@ CFLAGS="${OPTFLAGS}" CXXFLAGS="${OPTFLAGS}" ./configure --prefix="${PREFIX}" || 
 
 CPU_NUM=$(grep ^processor /proc/cpuinfo  | wc -l)
 make -j${CPU_NUM} install
-if [ -z "${SKIP_CHECK}" ]; then
-  #FIXME: get this working again
-  #make check
-  true
-fi
+# if [ -z "${SKIP_CHECK}" ]; then
+#   #FIXME: get this working again
+#   make check
+# fi
 git rev-parse HEAD > "${PREFIX}"/revision.txt
 cd ../..
 

--- a/bin/build_stackwalker.sh
+++ b/bin/build_stackwalker.sh
@@ -6,8 +6,7 @@
 
 # Build script for building Breakpad and stackwalker
 
-# Failures should cause setup to fail
-set -v -e -x
+set -euxo pipefail
 
 # Destination directory for the final stackwalker binaries
 STACKWALKDIR="${STACKWALKDIR:-$(pwd)/stackwalk}"

--- a/bin/clean_artifacts.sh
+++ b/bin/clean_artifacts.sh
@@ -6,6 +6,8 @@
 
 # Delete build artifacts from building breakpad and minidump-stackwalker
 
+set -euxo pipefail
+
 find pgo_data -name "*.extra" -exec rm -f {} \;
 find pgo_data -name "*.dmp" -exec rm -f {} \;
 find pgo_data -name "*.sym" -exec rm -f {} \;

--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -14,7 +14,7 @@
 #
 #    app@socorro:/app$ ./bin/run_mdsw.sh [CRASHID]
 
-set -e
+set -euxo pipefail
 
 DATADIR=./crashdata_mdsw_tmp
 OUTPUTDIR=./outdir


### PR DESCRIPTION
This adds -u which errors out when an unset variable is used. We've had
problems with unintentionally unset variables for ages, so it's prudent
to set it here.

This adds -o pipefail to error out the script if a pipe fails.