### PR TITLE
Minor fixes to project scaffolding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*.cc]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+
+[*.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ minidump-stackwalk/dumplookup
 minidump-stackwalk/get-minidump-instructions
 minidump-stackwalk/jit-crash-categorize
 dist/
+tmp/
+crashdata_mdsw_tmp/
+outdir/
 
 # docker things
 .docker-build*

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	    | sed -n 's/^\(.*\): \(.*\)##\(.*\)/\1\3/p' \
 	    | column -t  -s '|'
 	@echo ""
-	@echo "See https://socorro.readthedocs.io/ for more documentation."
+	@echo "See https://github.com/mozilla-services/minidump-stackwalk/ for more documentation."
 
 .env:
 	@if [ ! -f .env ]; \
@@ -56,6 +56,7 @@ shell: .env .docker-build  ## | Open a shell in the app container.
 clean:  ## | Remove all build artifacts.
 	-rm .docker-build*
 	./bin/clean_artifacts.sh
+	-rm -rf tmp
 
 sizeof: .env .docker-build  ## | Size of minidump_stackwalker docker image.
 	docker images | grep minidump

--- a/bin/run_mdsw.sh
+++ b/bin/run_mdsw.sh
@@ -16,8 +16,9 @@
 
 set -euxo pipefail
 
-DATADIR=./crashdata_mdsw_tmp
-OUTPUTDIR=./outdir
+DATADIR="/app/crashdata_mdsw_tmp"
+OUTPUTDIR="/app/outdir"
+SYMBOLS_TMP="/app/tmp"
 SYMBOLS_URL="https://symbols.mozilla.org/"
 STACKWALKER_PATH="/stackwalk/stackwalker"
 
@@ -37,9 +38,10 @@ if [ ! -d "${DATADIR}" ]; then
     exit 1
 fi
 
-mkdir -p /tmp/symbols/cache || true
-mkdir -p /tmp/symbols/tmp || true
-mkdir -p ${OUTPUTDIR} || true
+echo "Using ${SYMBOLS_TMP} for tmp and cache"
+mkdir -p "${SYMBOLS_TMP}/cache" || true
+mkdir -p "${SYMBOLS_TMP}/tmp" || true
+mkdir -p "${OUTPUTDIR}" || true
 
 for CRASHID in "$@"
 do
@@ -50,7 +52,7 @@ do
     timeout -s KILL 600 "${STACKWALKER_PATH}" \
         --raw-json ${RAWCRASHFILE} \
         --symbols-url "${SYMBOLS_URL}" \
-        --symbols-cache /tmp/symbols/cache \
-        --symbols-tmp /tmp/symbols/tmp \
+        --symbols-cache "${SYMBOLS_TMP}/cache" \
+        --symbols-tmp "${SYMBOLS_TMP}/tmp" \
         ${DUMPFILE} > ${OUTPUTDIR}/${CRASHID}.json
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,17 @@
+---
 version: "2"
 services:
   app:
     build:
       context: .
     image: local/socorro-minidump-stackwalk
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+
+  current:
+    image: mozilla/socorro-minidump-stackwalk:latest
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
* fix `bin/run_mdsw.sh` to use `/app/tmp` which is persisted outside the container so downloaded SYM files persist
* add removing `~/tmp` to clean rule in `Makefile`
* add `~/tmp` to `.gitignore`
* fix linting error in `docker-compose.yml`
* add `.editorconfig` for setting conventions across editors
* add `~/outdir/` and `~/crashdata_mdsw_tmp/` to `.gitignore` because they're ephemeral directories used by `bin/run_mdsw.sh`
* add "current" container which is `mozilla/socorro-minidump-stackwalk:latest` image from docker hub to make it really easy to compare output to the latest in main branch without having to recompile