### PR TITLE
Fix segfault when minidump fails to process

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -1424,8 +1424,6 @@ int main(int argc, char** argv)
 
   minidump.Read();
 
-  int minidump_width = determine_minidump_width(&minidump);
-
   // process minidump
   // bug 950710 - Bad symbol files are causing the stackwalker to
   // run amok. Disabling this until we get an upstream fix.
@@ -1451,6 +1449,11 @@ int main(int argc, char** argv)
 
   ProcessResult result =
     minidump_processor.Process(&minidump, &process_state);
+
+  int minidump_width = 64;
+  if (result == google_breakpad::PROCESS_OK) {
+    minidump_width = determine_minidump_width(&minidump);
+  }
 
   if (pipe) {
     if (result == google_breakpad::PROCESS_OK) {


### PR DESCRIPTION
When the minidump fails to process, then querying `system_info()` segfaults. Best to check the processing result first.

Before this change, stackwalk segfaults on 0-byte minidumps like what we have with fef248b7-cd01-498a-bc77-353b80210527 and 6caa9e0b-c983-4225-9e2d-0c5c00210526.

After this change, stackwalk spits out:

```
{"sensitive":{},"status":"ERROR_NO_MINIDUMP_HEADER"}
```

Fixes #37.