### PR TITLE
bug 1727733: Import the changes we applied to the m-c stackwalker to interpret new macOS crashes

### DIFF
--- a/bin/build_breakpad.sh
+++ b/bin/build_breakpad.sh
@@ -23,11 +23,11 @@ export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
 
 if [ ! -d "depot_tools" ]; then
-  git clone --depth=1 --single-branch https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  git clone --depth=1 --single-branch --branch main https://chromium.googlesource.com/chromium/tools/depot_tools.git
 fi
 
 cd depot_tools || exit
-git pull origin master
+git pull origin main
 echo ">>> using depot_tools version: $(git rev-parse HEAD)"
 cd ..
 

--- a/breakpad-patches/23-si-user-si-kernel-siginfo.patch
+++ b/breakpad-patches/23-si-user-si-kernel-siginfo.patch
@@ -1,0 +1,76 @@
+diff --git a/src/google_breakpad/common/minidump_exception_linux.h b/src/google_breakpad/common/minidump_exception_linux.h
+--- a/src/google_breakpad/common/minidump_exception_linux.h
++++ b/src/google_breakpad/common/minidump_exception_linux.h
+@@ -83,16 +83,20 @@ typedef enum {
+   MD_EXCEPTION_CODE_LIN_DUMP_REQUESTED = 0xFFFFFFFF /* No exception,
+                                                        dump requested. */
+ } MDExceptionCodeLinux;
+ 
+ /* For (MDException).exception_flags.  These values come from
+  * asm-generic/siginfo.h.
+  */
+ typedef enum {
++  /* Generic */
++  MD_EXCEPTION_FLAG_LIN_SI_USER = 0,
++  MD_EXCEPTION_FLAG_LIN_SI_KERNEL = 0x80,
++
+   /* SIGILL */
+   MD_EXCEPTION_FLAG_LIN_ILL_ILLOPC = 1,
+   MD_EXCEPTION_FLAG_LIN_ILL_ILLOPN = 2,
+   MD_EXCEPTION_FLAG_LIN_ILL_ILLADR = 3,
+   MD_EXCEPTION_FLAG_LIN_ILL_ILLTRP = 4,
+   MD_EXCEPTION_FLAG_LIN_ILL_PRVOPC = 5,
+   MD_EXCEPTION_FLAG_LIN_ILL_PRVREG = 6,
+   MD_EXCEPTION_FLAG_LIN_ILL_COPROC = 7,
+diff --git a/src/processor/minidump_processor.cc b/src/processor/minidump_processor.cc
+--- a/src/processor/minidump_processor.cc
++++ b/src/processor/minidump_processor.cc
+@@ -1401,16 +1401,22 @@ string MinidumpProcessor::GetCrashReason
+           reason = "SIGTRAP";
+           break;
+         case MD_EXCEPTION_CODE_LIN_SIGABRT:
+           reason = "SIGABRT";
+           break;
+         case MD_EXCEPTION_CODE_LIN_SIGBUS:
+           reason = "SIGBUS / ";
+           switch (exception_flags) {
++            case MD_EXCEPTION_FLAG_LIN_SI_USER:
++              reason.append("SI_USER");
++              break;
++            case MD_EXCEPTION_FLAG_LIN_SI_KERNEL:
++              reason.append("SI_KERNEL");
++              break;
+             case MD_EXCEPTION_FLAG_LIN_BUS_ADRALN:
+               reason.append("BUS_ADRALN");
+               break;
+             case MD_EXCEPTION_FLAG_LIN_BUS_ADRERR:
+               reason.append("BUS_ADRERR");
+               break;
+             case MD_EXCEPTION_FLAG_LIN_BUS_OBJERR:
+               reason.append("BUS_OBJERR");
+@@ -1462,18 +1468,24 @@ string MinidumpProcessor::GetCrashReason
+           break;
+         case MD_EXCEPTION_CODE_LIN_SIGKILL:
+           reason = "SIGKILL";
+           break;
+         case MD_EXCEPTION_CODE_LIN_SIGUSR1:
+           reason = "SIGUSR1";
+           break;
+         case MD_EXCEPTION_CODE_LIN_SIGSEGV:
+-          reason = "SIGSEGV /";
++          reason = "SIGSEGV / ";
+           switch (exception_flags) {
++            case MD_EXCEPTION_FLAG_LIN_SI_USER:
++              reason.append("SI_USER");
++              break;
++            case MD_EXCEPTION_FLAG_LIN_SI_KERNEL:
++              reason.append("SI_KERNEL");
++              break;
+             case MD_EXCEPTION_FLAG_LIN_SEGV_MAPERR:
+               reason.append("SEGV_MAPERR");
+               break;
+             case MD_EXCEPTION_FLAG_LIN_SEGV_ACCERR:
+               reason.append("SEGV_ACCERR");
+               break;
+             case MD_EXCEPTION_FLAG_LIN_SEGV_BNDERR:
+               reason.append("SEGV_BNDERR");

--- a/breakpad-patches/24-macos-exc-resource.patch
+++ b/breakpad-patches/24-macos-exc-resource.patch
@@ -1,0 +1,155 @@
+diff --git a/src/google_breakpad/common/minidump_exception_mac.h b/src/google_breakpad/common/minidump_exception_mac.h
+--- a/src/google_breakpad/common/minidump_exception_mac.h
++++ b/src/google_breakpad/common/minidump_exception_mac.h
+@@ -62,16 +62,18 @@ typedef enum {
+   MD_EXCEPTION_MAC_BREAKPOINT      = 6,  /* code is CPU-specific */
+       /* EXC_BREAKPOINT */
+   MD_EXCEPTION_MAC_SYSCALL         = 7,
+       /* EXC_SYSCALL */
+   MD_EXCEPTION_MAC_MACH_SYSCALL    = 8,
+       /* EXC_MACH_SYSCALL */
+   MD_EXCEPTION_MAC_RPC_ALERT       = 9,
+       /* EXC_RPC_ALERT */
++  MD_EXCEPTION_MAC_RESOURCE        = 11,
++      /* EXC_RESOURCE */
+   MD_EXCEPTION_MAC_SIMULATED       = 0x43507378
+       /* Fake exception code used by Crashpad's SimulateCrash ('CPsx'). */
+ } MDExceptionMac;
+ 
+ /* For (MDException).exception_flags.  Breakpad minidump extension for Mac OS X
+  * support.  Based on Darwin/Mac OS X' mach/ppc/exception.h and
+  * mach/i386/exception.h.  This is what Mac OS X calls a "code". */
+ typedef enum {
+@@ -201,9 +203,42 @@ typedef enum {
+   /* EXC_I386_PGFLT     = 14: should not occur in user space */
+   /* EXC_I386_EXTERRFLT = 16: mapped to EXC_ARITHMETIC/EXC_I386_EXTERR */
+   MD_EXCEPTION_CODE_MAC_X86_ALIGNMENT_FAULT            = 17
+       /* EXC_ALIGNFLT (for vector operations) */
+   /* EXC_I386_ENOEXTFLT = 32: should be handled by the kernel */
+   /* EXC_I386_ENDPERR   = 33: should not occur */
+ } MDExceptionCodeMac;
+ 
++// The following definitions were taken from  Darwin/XNU kernel sources.
++// See https://github.com/apple/darwin-xnu/blob/main/osfmk/kern/exc_resource.h
++
++typedef enum MDMacExcResourceType {
++  MD_MAC_EXC_RESOURCE_TYPE_CPU     = 1,
++  MD_MAC_EXC_RESOURCE_TYPE_WAKEUPS = 2,
++  MD_MAC_EXC_RESOURCE_TYPE_MEMORY  = 3,
++  MD_MAC_EXC_RESOURCE_TYPE_IO      = 4,
++  MD_MAC_EXC_RESOURCE_TYPE_THREADS = 5
++} MDMacExcResourceType;
++
++typedef enum MDMacExcResourceFlavorCpu {
++  MD_MAC_EXC_RESOURCE_FLAVOR_CPU_MONITOR       = 1,
++  MD_MAC_EXC_RESOURCE_FLAVOR_CPU_MONITOR_FATAL = 2
++} MDMacExcResourceFlavorCpu;
++
++typedef enum MDMacExcResourceFlavorWakeup {
++  MD_MAC_EXC_RESOURCE_FLAVOR_WAKEUPS_MONITOR = 1,
++} MDMacExcResourceFlavorWakeup;
++
++typedef enum MDMacExcResourceFlavorMemory {
++  MD_MAC_EXC_RESOURCE_FLAVOR_HIGH_WATERMARK = 1,
++} MDMacExcResourceFlavorMemory;
++
++typedef enum MDMacExcResourceIOFlavor {
++  MD_MAC_EXC_RESOURCE_FLAVOR_IO_PHYSICAL_WRITES = 1,
++  MD_MAC_EXC_RESOURCE_FLAVOR_IO_LOGICAL_WRITES = 2,
++} MDMacExcResourceIOFlavor;
++
++typedef enum MDMacExcResourceThreadsFlavor {
++  MD_MAC_EXC_RESOURCE_FLAVOR_THREADS_HIGH_WATERMARK = 1,
++} MDMacExcResourceThreadsFlavor;
++
+ #endif  /* GOOGLE_BREAKPAD_COMMON_MINIDUMP_EXCEPTION_MAC_OSX_H__ */
+diff --git a/src/processor/minidump_processor.cc b/src/processor/minidump_processor.cc
+--- a/src/processor/minidump_processor.cc
++++ b/src/processor/minidump_processor.cc
+@@ -1143,16 +1143,86 @@ string MinidumpProcessor::GetCrashReason
+         case MD_EXCEPTION_MAC_MACH_SYSCALL:
+           reason = "EXC_MACH_SYSCALL / ";
+           reason.append(flags_string);
+           break;
+         case MD_EXCEPTION_MAC_RPC_ALERT:
+           reason = "EXC_RPC_ALERT / ";
+           reason.append(flags_string);
+           break;
++        case MD_EXCEPTION_MAC_RESOURCE:
++          reason = "EXC_RESOURCE / ";
++          {
++            uint32_t type = (exception_flags >> 29) & 0x7ULL;
++            uint32_t flavor = (exception_flags >> 26) & 0x7ULL;
++            char flavor_string[4] = {};
++            switch (type) {
++              case MD_MAC_EXC_RESOURCE_TYPE_CPU:
++                reason.append("RESOURCE_TYPE_CPU / ");
++                switch (flavor) {
++                  case MD_MAC_EXC_RESOURCE_FLAVOR_CPU_MONITOR:
++                    reason.append("FLAVOR_CPU_MONITOR");
++                    break;
++                  case MD_MAC_EXC_RESOURCE_FLAVOR_CPU_MONITOR_FATAL:
++                    reason.append("FLAVOR_CPU_MONITOR_FATAL");
++                    break;
++                  default:
++                    snprintf(flavor_string, sizeof(flavor_string), "%#3x", flavor);
++                    reason.append(flavor_string);
++                    break;
++                }
++                break;
++              case MD_MAC_EXC_RESOURCE_TYPE_WAKEUPS:
++                reason.append("RESOURCE_TYPE_WAKEUPS / ");
++                if (flavor == MD_MAC_EXC_RESOURCE_FLAVOR_WAKEUPS_MONITOR) {
++                  reason.append("FLAVOR_WAKEUPS_MONITOR");
++                } else {
++                  snprintf(flavor_string, sizeof(flavor_string), "%#3x", flavor);
++                  reason.append(flavor_string);
++                }
++                break;
++              case MD_MAC_EXC_RESOURCE_TYPE_MEMORY:
++                reason.append("RESOURCE_TYPE_MEMORY / ");
++                if (flavor == MD_MAC_EXC_RESOURCE_FLAVOR_HIGH_WATERMARK) {
++                  reason.append("FLAVOR_HIGH_WATERMARK");
++                } else {
++                  snprintf(flavor_string, sizeof(flavor_string), "%#3x", flavor);
++                  reason.append(flavor_string);
++                }
++                break;
++              case MD_MAC_EXC_RESOURCE_TYPE_IO:
++                reason.append("EXC_RESOURCE_TYPE_IO / ");
++                switch (flavor) {
++                  case MD_MAC_EXC_RESOURCE_FLAVOR_IO_PHYSICAL_WRITES:
++                    reason.append("FLAVOR_IO_PHYSICAL_WRITES");
++                    break;
++                  case MD_MAC_EXC_RESOURCE_FLAVOR_IO_LOGICAL_WRITES:
++                    reason.append("FLAVOR_IO_LOGICAL_WRITES");
++                    break;
++                  default:
++                    snprintf(flavor_string, sizeof(flavor_string), "%#3x", flavor);
++                    reason.append(flavor_string);
++                    break;
++                }
++                break;
++              case MD_MAC_EXC_RESOURCE_TYPE_THREADS:
++                reason.append("EXC_RESOURCE_TYPE_THREADS / ");
++                if (flavor == MD_MAC_EXC_RESOURCE_FLAVOR_THREADS_HIGH_WATERMARK) {
++                  reason.append("FLAVOR_THREADS_HIGH_WATERMARK");
++                } else {
++                  snprintf(flavor_string, sizeof(flavor_string), "%#3x", flavor);
++                  reason.append(flavor_string);
++                }
++                break;
++              default:
++                reason.append(flags_string);
++                break;
++            }
++          }
++          break;
+         case MD_EXCEPTION_MAC_SIMULATED:
+           reason = "Simulated Exception";
+           break;
+       }
+       break;
+     }
+ 
+     case MD_OS_WIN32_NT:

--- a/breakpad-patches/25-macos-exc-guard.patch
+++ b/breakpad-patches/25-macos-exc-guard.patch
@@ -1,0 +1,349 @@
+diff --git a/src/google_breakpad/common/minidump_exception_mac.h b/src/google_breakpad/common/minidump_exception_mac.h
+--- a/src/google_breakpad/common/minidump_exception_mac.h
++++ b/src/google_breakpad/common/minidump_exception_mac.h
+@@ -64,16 +64,18 @@ typedef enum {
+   MD_EXCEPTION_MAC_SYSCALL         = 7,
+       /* EXC_SYSCALL */
+   MD_EXCEPTION_MAC_MACH_SYSCALL    = 8,
+       /* EXC_MACH_SYSCALL */
+   MD_EXCEPTION_MAC_RPC_ALERT       = 9,
+       /* EXC_RPC_ALERT */
+   MD_EXCEPTION_MAC_RESOURCE        = 11,
+       /* EXC_RESOURCE */
++  MD_EXCEPTION_MAC_GUARD           = 12,
++      /* EXC_GUARD */
+   MD_EXCEPTION_MAC_SIMULATED       = 0x43507378
+       /* Fake exception code used by Crashpad's SimulateCrash ('CPsx'). */
+ } MDExceptionMac;
+ 
+ /* For (MDException).exception_flags.  Breakpad minidump extension for Mac OS X
+  * support.  Based on Darwin/Mac OS X' mach/ppc/exception.h and
+  * mach/i386/exception.h.  This is what Mac OS X calls a "code". */
+ typedef enum {
+@@ -236,9 +238,77 @@ typedef enum MDMacExcResourceIOFlavor {
+   MD_MAC_EXC_RESOURCE_FLAVOR_IO_PHYSICAL_WRITES = 1,
+   MD_MAC_EXC_RESOURCE_FLAVOR_IO_LOGICAL_WRITES = 2,
+ } MDMacExcResourceIOFlavor;
+ 
+ typedef enum MDMacExcResourceThreadsFlavor {
+   MD_MAC_EXC_RESOURCE_FLAVOR_THREADS_HIGH_WATERMARK = 1,
+ } MDMacExcResourceThreadsFlavor;
+ 
++// See https://github.com/apple/darwin-xnu/blob/main/osfmk/kern/exc_guard.h
++
++typedef enum MDMacExcGuardType {
++  MD_MAC_EXC_GUARD_TYPE_NONE        = 0x0,
++  MD_MAC_EXC_GUARD_TYPE_MACH_PORT   = 0x1,
++  MD_MAC_EXC_GUARD_TYPE_FD          = 0x2,
++  MD_MAC_EXC_GUARD_TYPE_USER        = 0x3,
++  MD_MAC_EXC_GUARD_TYPE_VN          = 0x4,
++  MD_MAC_EXC_GUARD_TYPE_VIRT_MEMORY = 0x5
++} MDMacExcGuardType;
++
++// See https://github.com/apple/darwin-xnu/osfmk/mach/port.h
++
++typedef enum MDMacExcGuardMachPortFlavor {
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_DESTROY              = 1u << 0,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MOD_REFS             = 1u << 1,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SET_CONTEXT          = 1u << 2,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_UNGUARDED            = 1u << 3,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INCORRECT_GUARD      = 1u << 4,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_IMMOVABLE            = 1u << 5,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_STRICT_REPLY         = 1u << 6,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MSG_FILTERED         = 1u << 7,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_RIGHT        = 1u << 8,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_NAME         = 1u << 9,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_VALUE        = 1u << 10,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_ARGUMENT     = 1u << 11,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RIGHT_EXISTS         = 1u << 12,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_NO_SPACE        = 1u << 13,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_FAILURE         = 1u << 14,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_RESOURCE        = 1u << 15,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_REPLY   = 1u << 16,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_VOUCHER = 1u << 17,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_RIGHT   = 1u << 18,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RCV_INVALID_NAME     = 1u << 19,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RCV_GUARDED_DESC     = 1u << 20,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MOD_REFS_NON_FATAL   = 1u << 21,
++  MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_IMMOVABLE_NON_FATAL  = 1u << 22,
++} MDMacExcGuardMachPortFlavor;
++
++// See https://github.com/apple/darwin-xnu/blob/main/bsd/sys/guarded.h
++
++typedef enum MDMacExcGuardFDFlavor {
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_CLOSE      = 1u << 0,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_DUP        = 1u << 1,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_NOCLOEXEC  = 1u << 2,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_SOCKET_IPC = 1u << 3,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_FILEPORT   = 1u << 4,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_MISMATCH   = 1u << 5,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_WRITE      = 1u << 6
++} MDMacExcGuardFDFlavor;
++
++
++typedef enum MDMacExcGuardVNFlavor {
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_RENAME_TO   = 1u << 0,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_RENAME_FROM = 1u << 1,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_UNLINK      = 1u << 2,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_WRITE_OTHER = 1u << 3,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_TRUNC_OTHER = 1u << 4,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_LINK        = 1u << 5,
++  MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_EXCHDATA    = 1u << 6,
++} MDMacExcGuardVNFlavor;
++
++// See https://github.com/apple/darwin-xnu/osfmk/mach/vm_statistics.h
++
++typedef enum MDMacExcGuardVirtMemoryFlavor {
++  MD_MAC_EXC_GUARD_VIRT_MEMORY_FLAVOR_GUARD_EXC_DEALLOC_GAP = 1u << 0
++} MDMacExcGuardVirtMemoryFlavor;
++
+ #endif  /* GOOGLE_BREAKPAD_COMMON_MINIDUMP_EXCEPTION_MAC_OSX_H__ */
+diff --git a/src/processor/minidump_processor.cc b/src/processor/minidump_processor.cc
+--- a/src/processor/minidump_processor.cc
++++ b/src/processor/minidump_processor.cc
+@@ -1213,16 +1213,245 @@ string MinidumpProcessor::GetCrashReason
+                 }
+                 break;
+               default:
+                 reason.append(flags_string);
+                 break;
+             }
+           }
+           break;
++        case MD_EXCEPTION_MAC_GUARD:
++          reason = "EXC_GUARD / ";
++          {
++            uint32_t type = (exception_flags >> 29) & 0x7ULL;
++            uint32_t flavor = exception_flags & 0x1FFFFFFFULL;
++            switch (type) {
++              case MD_MAC_EXC_GUARD_TYPE_NONE:
++                reason.append("GUARD_TYPE_NONE");
++                break;
++              case MD_MAC_EXC_GUARD_TYPE_MACH_PORT:
++                reason.append("GUARD_TYPE_MACH_PORT");
++
++                if (flavor) {
++                  std::vector<std::string> flavors;
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_DESTROY) {
++                    flavors.push_back("GUARD_EXC_DESTROY");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MOD_REFS) {
++                    flavors.push_back("GUARD_EXC_MOD_REFS");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SET_CONTEXT) {
++                    flavors.push_back("GUARD_EXC_SET_CONTEXT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SET_CONTEXT) {
++                    flavors.push_back("GUARD_EXC_SET_CONTEXT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_UNGUARDED) {
++                    flavors.push_back("GUARD_EXC_UNGUARDED");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INCORRECT_GUARD) {
++                    flavors.push_back("GUARD_EXC_INCORRECT_GUARD");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_IMMOVABLE) {
++                    flavors.push_back("GUARD_EXC_IMMOVABLE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_STRICT_REPLY) {
++                    flavors.push_back("GUARD_EXC_STRICT_REPLY");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MSG_FILTERED) {
++                    flavors.push_back("GUARD_EXC_MSG_FILTERED");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_RIGHT) {
++                    flavors.push_back("GUARD_EXC_INVALID_RIGHT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_NAME) {
++                    flavors.push_back("GUARD_EXC_INVALID_NAME");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_VALUE) {
++                    flavors.push_back("GUARD_EXC_INVALID_VALUE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_INVALID_ARGUMENT) {
++                    flavors.push_back("GUARD_EXC_INVALID_ARGUMENT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RIGHT_EXISTS) {
++                    flavors.push_back("GUARD_EXC_RIGHT_EXISTS");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_NO_SPACE) {
++                    flavors.push_back("GUARD_EXC_KERN_NO_SPACE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_FAILURE) {
++                    flavors.push_back("GUARD_EXC_KERN_FAILURE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_KERN_RESOURCE) {
++                    flavors.push_back("GUARD_EXC_KERN_RESOURCE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_REPLY) {
++                    flavors.push_back("GUARD_EXC_SEND_INVALID_REPLY");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_VOUCHER) {
++                    flavors.push_back("GUARD_EXC_SEND_INVALID_VOUCHER");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_SEND_INVALID_RIGHT) {
++                    flavors.push_back("GUARD_EXC_SEND_INVALID_RIGHT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RCV_INVALID_NAME) {
++                    flavors.push_back("GUARD_EXC_RCV_INVALID_NAME");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_RCV_GUARDED_DESC) {
++                    flavors.push_back("GUARD_EXC_RCV_GUARDED_DESC");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_MOD_REFS_NON_FATAL) {
++                    flavors.push_back("GUARD_EXC_MOD_REFS_NON_FATAL");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_MACH_PORT_FLAVOR_GUARD_EXC_IMMOVABLE_NON_FATAL) {
++                    flavors.push_back("GUARD_EXC_IMMOVABLE_NON_FATAL");
++                  }
++
++                  reason.append(" / ");
++                  for (size_t i = 0; i < flavors.size(); i++) {
++                    if (i > 0) {
++                      reason.append(" | ");
++                    }
++
++                    reason.append(flavors[i]);
++                  }
++                }
++
++                break;
++              case MD_MAC_EXC_GUARD_TYPE_FD:
++                reason.append("GUARD_TYPE_FD");
++
++                if (flavor) {
++                  std::vector<std::string> flavors;
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_CLOSE) {
++                    flavors.push_back("GUARD_EXC_CLOSE");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_DUP) {
++                    flavors.push_back("GUARD_EXC_DUP");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_NOCLOEXEC) {
++                    flavors.push_back("GUARD_EXC_NOCLOEXEC");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_SOCKET_IPC) {
++                    flavors.push_back("GUARD_EXC_SOCKET_IPC");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_FILEPORT) {
++                    flavors.push_back("GUARD_EXC_FILEPORT");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_MISMATCH) {
++                    flavors.push_back("GUARD_EXC_MISMATCH");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_WRITE) {
++                    flavors.push_back("GUARD_EXC_WRITE");
++                  }
++
++                  reason.append(" / ");
++                  for (size_t i = 0; i < flavors.size(); i++) {
++                    if (i > 0) {
++                      reason.append(" | ");
++                    }
++
++                    reason.append(flavors[i]);
++                  }
++                }
++
++                break;
++              case MD_MAC_EXC_GUARD_TYPE_USER:
++                reason.append("GUARD_TYPE_USER");
++                break;
++              case MD_MAC_EXC_GUARD_TYPE_VN:
++                reason.append("GUARD_TYPE_VN");
++
++                if (flavor) {
++                  std::vector<std::string> flavors;
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_RENAME_TO) {
++                    flavors.push_back("GUARD_EXC_RENAME_TO");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_RENAME_FROM) {
++                    flavors.push_back("GUARD_EXC_RENAME_FROM");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_UNLINK) {
++                    flavors.push_back("GUARD_EXC_UNLINK");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_WRITE_OTHER) {
++                    flavors.push_back("GUARD_EXC_WRITE_OTHER");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_TRUNC_OTHER) {
++                    flavors.push_back("GUARD_EXC_TRUNC_OTHER");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_LINK) {
++                    flavors.push_back("GUARD_EXC_LINK");
++                  }
++
++                  if (flavor & MD_MAC_EXC_GUARD_FD_FLAVOR_GUARD_EXC_EXCHDATA) {
++                    flavors.push_back("GUARD_EXC_EXCHDATA");
++                  }
++
++                  reason.append(" / ");
++                  for (size_t i = 0; i < flavors.size(); i++) {
++                    if (i > 0) {
++                      reason.append(" | ");
++                    }
++
++                    reason.append(flavors[i]);
++                  }
++                }
++
++                break;
++              case MD_MAC_EXC_GUARD_TYPE_VIRT_MEMORY:
++                reason.append("GUARD_TYPE_VIRT_MEMORY");
++
++                if (flavor & MD_MAC_EXC_GUARD_VIRT_MEMORY_FLAVOR_GUARD_EXC_DEALLOC_GAP) {
++                  reason.append(" / GUARD_EXC_DEALLOC_GAP");
++                }
++
++                break;
++              default:
++                reason.append(flags_string);
++                break;
++            }
++          }
++          break;
+         case MD_EXCEPTION_MAC_SIMULATED:
+           reason = "Simulated Exception";
+           break;
+       }
+       break;
+     }
+ 
+     case MD_OS_WIN32_NT:


### PR DESCRIPTION
This makes the stackwalker understand macOS's EXC_RESOURCE and EXC_GUARD
exceptions. The origin of certain Linux signals is also clarified.